### PR TITLE
Some Changes for Manager

### DIFF
--- a/config/routes.cr
+++ b/config/routes.cr
@@ -15,6 +15,7 @@ Amber::Server.configure do
 
   routes :api do
     resources "/users", UserController, except: [:new, :edit, :create]
+    get "/users/:id/runner", UserController, :runner
     get "/user", CurrentUserController, :show
     put "/user", CurrentUserController, :update
     patch "/user", CurrentUserController, :update

--- a/src/controllers/current_user_controller.cr
+++ b/src/controllers/current_user_controller.cr
@@ -4,13 +4,13 @@ class CurrentUserController < ApplicationController
   end
 
   def show
-    UserRenderer.render current_user
+    DetailedUserRenderer.render current_user
   end
 
   def update
     current_user.set_attributes(params.select(%w(email name)))
     if current_user.valid? && current_user.save
-      UserRenderer.render current_user
+      DetailedUserRenderer.render current_user
     else
       bad_request! t("errors.user.update")
     end

--- a/src/controllers/runner_controller.cr
+++ b/src/controllers/runner_controller.cr
@@ -9,12 +9,14 @@ class RunnerController < ApplicationController
   def index
     status = Runner::Status.parse(params["status"]? || "approved")
     authenticate!(User::Position::Manager).try { |e| return e } unless status.approved?
-    RunnerRenderer.render paginate(Runner.where(status_number: status.value)), approver?: current_user?.try &.position!.manager?
+    users? = current_user?.try &.position!.manager?
+    RunnerRenderer.render paginate(Runner.where(status_number: status.value)), user?: users?, approver?: users?
   end
 
   def show
     authenticate!(User::Position::Manager).try { |e| return e } unless runner.status!.approved?
-    RunnerRenderer.render runner, approver?: current_user?.try &.position!.manager?
+    users? = current_user?.try &.position!.manager?
+    RunnerRenderer.render runner, user?: users?, approver?: users?
   end
 
   def update_status

--- a/src/controllers/user_controller.cr
+++ b/src/controllers/user_controller.cr
@@ -2,8 +2,8 @@ class UserController < ApplicationController
   property! user : User
 
   before_action do
-    only [:show, :update, :destroy] { set_user }
-    only [:update, :destroy] { authenticate!(User::Position::Manager) }
+    only [:show, :update, :destroy, :runner] { set_user }
+    only [:update, :destroy, :runner] { authenticate!(User::Position::Manager) }
   end
 
   def index
@@ -27,6 +27,11 @@ class UserController < ApplicationController
   def destroy
     user.destroy
     UserRenderer.render user
+  end
+
+  def runner
+    not_found! t("errors.user.runner.not_found") unless user.runner
+    RunnerRenderer.render user.runner!, user?: false, approver?: true
   end
 
   def user_params

--- a/src/controllers/user_controller.cr
+++ b/src/controllers/user_controller.cr
@@ -7,18 +7,18 @@ class UserController < ApplicationController
   end
 
   def index
-    UserRenderer.render paginate User
+    UserRenderer.render paginate(User), fb_id?: current_user?.try &.position!.manager?
   end
 
   def show
-    UserRenderer.render user
+    UserRenderer.render user, fb_id?: current_user?.try &.position!.manager?
   end
 
   def update
     user.set_attributes(user_params.validate!)
     user.position = params["position"]
     if user.valid? && user.save
-      UserRenderer.render user
+      DetailedUserRenderer.render user
     else
       bad_request! t("errors.user.update")
     end
@@ -26,7 +26,7 @@ class UserController < ApplicationController
 
   def destroy
     user.destroy
-    UserRenderer.render user
+    DetailedUserRenderer.render user
   end
 
   def runner

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -9,6 +9,8 @@ errors:
     denied: "You don't have permission."
     not_found: "User with id %{id} not found."
     update: "Could not update user!"
+    runner:
+      not_found: "This user is not a runner."
   runner:
     not_found: "Runner with id %{id} not found."
     create: "Could not create runner!"

--- a/src/models/user.cr
+++ b/src/models/user.cr
@@ -8,6 +8,7 @@ class User < Granite::Base
   table_name users
   before_create set_defaults
 
+  has_one runner : Runner
   field fb_id : String
   field email : String
   field name : String

--- a/src/renderers/detailed_user.cr
+++ b/src/renderers/detailed_user.cr
@@ -1,0 +1,5 @@
+require "./user"
+
+class DetailedUserRenderer < UserRenderer
+  field fb_id : String
+end

--- a/src/renderers/runner.cr
+++ b/src/renderers/runner.cr
@@ -1,7 +1,9 @@
 class RunnerRenderer < Crinder::Base(Runner)
   class_getter? approver : Bool? = false
+  class_getter? user : Bool? = false
 
   field id : Int?
+  field user, with: UserRenderer, value: -> { object.user_id.try { user } }, if: user?
   field name : String
   field alternative_name : String?
   field english_name : String?
@@ -10,12 +12,12 @@ class RunnerRenderer < Crinder::Base(Runner)
   field phone : String
   field organization : String?
   field status : String
-  field approver, with: UserRenderer, value: ->{ object.approver_id ? approver : nil }, if: approver?
+  field approver, with: UserRenderer, value: ->{ object.approver_id.try { approver } }, if: approver?
   field approved_at : String?
   field created_at : String
   field updated_at : String
 
-  def self.render(runner, approver? @@approver)
+  def self.render(runner, user? @@user = false, approver? @@approver = false)
     render(runner)
   end
 end

--- a/src/renderers/runner.cr
+++ b/src/renderers/runner.cr
@@ -3,7 +3,7 @@ class RunnerRenderer < Crinder::Base(Runner)
   class_getter? user : Bool? = false
 
   field id : Int?
-  field user, with: UserRenderer, value: -> { object.user_id.try { user } }, if: user?
+  field user, with: DetailedUserRenderer, value: -> { object.user_id.try { user } }, if: user?
   field name : String
   field alternative_name : String?
   field english_name : String?

--- a/src/renderers/runner_error.cr
+++ b/src/renderers/runner_error.cr
@@ -5,6 +5,6 @@ class RunnerErrorRenderer < Crinder::Base(RunnerError)
   field description : String
 
   def self.render(@@title, error : RunnerError)
-    self.render(error)
+    render(error)
   end
 end

--- a/src/renderers/user.cr
+++ b/src/renderers/user.cr
@@ -1,8 +1,15 @@
 class UserRenderer < Crinder::Base(User?)
+  class_getter? fb_id : Bool? = false
+
   field id : Int?
+  field fb_id : String, if: fb_id?
   field name : String
   field email : String
   field position : String
   field created_at : String
   field updated_at : String
+
+  def self.render(user, fb_id? @@fb_id = false)
+    render(user)
+  end
 end


### PR DESCRIPTION
1. 當 `current_user` 是 `Manager` 時 `GET /runners`、`GET /runners/:id` 會帶 `user`：
想到審查新跑者的時候應該要帶這些資訊比較好。
2. 新增 `GET /users/:id/runner` 需要 `Manager`：
雖然不知道有什麼用途。
3. `GET /user`、`PATCH /user`、`PATCH /users/:id`、`DELETE /users/:id`、1. 裡的 `user` 會帶 `fb_id`，還有當 `current_user` 是 `Manager` 時 `GET /users`、`GET /users/:id` 也是：
覺得審查新跑者的時候，管理員應該要能確認他的 FB。
不過寫完才想到 FB 不知道有沒有辦法從 `fb_id` 就獲得個人檔案頁面？
如果沒有的話，後端可能要再加個 `fb_link` 之類的欄位。